### PR TITLE
Persist image on S3 with thumbnail

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -54,7 +54,7 @@ class HomesController < ApplicationController
 
     if @home.save
       (retrieved_data&.dig(:images) || []).each do |img|
-        @home.images.create(url: img)
+        @home.images.create(external_url: img)
       end
       redirect_to hunt_home_path(@hunt, @home), notice: 'Home was successfully created.'
     else
@@ -110,7 +110,7 @@ class HomesController < ApplicationController
       :rightmove_url,
       :price,
       :hunt_id,
-      images_attributes: %i[id url _destroy]
+      images_attributes: %i[id external_url _destroy]
     )
   end
 end

--- a/app/jobs/image_persist_job.rb
+++ b/app/jobs/image_persist_job.rb
@@ -12,7 +12,7 @@ class ImagePersistJob < ApplicationJob
     steps = []
     steps << transloadit.step('original',
                               '/http/import',
-                              url: image.url)
+                              url: image.external_url)
     steps << transloadit.step('filter',
                               '/file/filter',
                               use: 'original',

--- a/app/jobs/image_persist_job.rb
+++ b/app/jobs/image_persist_job.rb
@@ -45,10 +45,8 @@ class ImagePersistJob < ApplicationJob
       original = results.fetch('original').fetch(0).fetch('ssl_url')
       thumb = results.fetch('thumb').fetch(0).fetch('ssl_url')
 
-      # TODO: Persist 'original' and 'thumb' URLs to Image record
-      puts 'Uploaded files;'
-      puts "Original: #{original}"
-      puts "Thumb: #{thumb}"
+      # Persist 'original' and 'thumb' URLs to Image record
+      image.update!(full_url: original, thumb_url: thumb)
     end
   end
 end

--- a/app/models/home.rb
+++ b/app/models/home.rb
@@ -31,7 +31,7 @@ class Home < ApplicationRecord
   accepts_nested_attributes_for :images, reject_if: :mark_empty_images_for_destruction, allow_destroy: true
 
   def default_thumb
-    images.first&.thumb_url || placeholder_image
+    images.first&.thumb_url_fallback || placeholder_image
   end
 
   def placeholder_image

--- a/app/models/home.rb
+++ b/app/models/home.rb
@@ -30,8 +30,8 @@ class Home < ApplicationRecord
 
   accepts_nested_attributes_for :images, reject_if: :mark_empty_images_for_destruction, allow_destroy: true
 
-  def default_image
-    images.first&.url || placeholder_image
+  def default_thumb
+    images.first&.thumb_url || placeholder_image
   end
 
   def placeholder_image

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -3,5 +3,15 @@ class Image < ApplicationRecord
 
   default_scope { order(:id) }
 
-  auto_strip_attributes :url, squish: true
+  auto_strip_attributes :external_url, squish: true
+
+  def full_url
+    # TODO: Rely on persisted URL, falling back to external
+    external_url
+  end
+
+  def thumb_url
+    # TODO: Rely on generated thumbnail URL, falling back to external
+    external_url
+  end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -5,13 +5,11 @@ class Image < ApplicationRecord
 
   auto_strip_attributes :external_url, squish: true
 
-  def full_url
-    # TODO: Rely on persisted URL, falling back to external
-    external_url
+  def full_url_fallback
+    full_url || external_url
   end
 
-  def thumb_url
-    # TODO: Rely on generated thumbnail URL, falling back to external
-    external_url
+  def thumb_url_fallback
+    thumb_url || external_url
   end
 end

--- a/app/views/homes/_form.html.erb
+++ b/app/views/homes/_form.html.erb
@@ -110,7 +110,7 @@
       <% if images_form.object.persisted? %>
         <div class="form-group col-md-3">
           <%= images_form.label :_destroy do %>
-            <%= image_tag images_form.object.thumb_url, class: 'img-thumbnail' %>
+            <%= image_tag images_form.object.thumb_url_fallback, class: 'img-thumbnail' %>
           <% end %>
           <%= images_form.check_box :_destroy, class: 'form-check-input' %>
           <%#= images_form.label :_destroy, class: 'form-check-label' %>

--- a/app/views/homes/_form.html.erb
+++ b/app/views/homes/_form.html.erb
@@ -110,17 +110,17 @@
       <% if images_form.object.persisted? %>
         <div class="form-group col-md-3">
           <%= images_form.label :_destroy do %>
-            <%= image_tag images_form.object.url, class: 'img-thumbnail' %>
+            <%= image_tag images_form.object.thumb_url, class: 'img-thumbnail' %>
           <% end %>
           <%= images_form.check_box :_destroy, class: 'form-check-input' %>
           <%#= images_form.label :_destroy, class: 'form-check-label' %>
           <br>
-          <%= images_form.text_field :url, class: 'form-control' %>
+          <%= images_form.text_field :external_url, disabled: true, class: 'form-control' %>
         </div>
       <% else %>
         <div class="form-group col-md-3">
-          <%= images_form.label :url %>
-          <%= images_form.text_field :url, class: 'form-control' %>
+          <%= images_form.label :external_url, 'URL' %>
+          <%= images_form.text_field :external_url, class: 'form-control' %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/homes/_images_carousel.html.erb
+++ b/app/views/homes/_images_carousel.html.erb
@@ -5,7 +5,7 @@
   <div class="carousel-inner shadow">
     <% images.each_with_index do |image, idx| %>
       <div class="<%= 'active' if idx.zero? %> carousel-item" data-slide-number="<%= idx %>">
-        <%= image_tag image.full_url, class: 'd-block w-100', alt: "Image #{idx + 1} of #{images.size}" %>
+        <%= image_tag image.full_url_fallback, class: 'd-block w-100', alt: "Image #{idx + 1} of #{images.size}" %>
       </div>
     <% end %>
 
@@ -27,7 +27,7 @@
                     id: "carousel-selector-#{idx}",
                     class: idx.zero? ? 'selected' : '',
                     data: { 'slide-to': idx, target: '#homeImagesCarousel' } do %>
-          <%= image_tag image.thumb_url, class: 'img-fluid', style: 'max-height: 100px;', alt: "Image #{idx + 1} of #{images.size}" %>
+          <%= image_tag image.thumb_url_fallback, class: 'img-fluid', style: 'max-height: 100px;', alt: "Image #{idx + 1} of #{images.size}" %>
         <% end %>
       </li>
     <% end %>

--- a/app/views/homes/_images_carousel.html.erb
+++ b/app/views/homes/_images_carousel.html.erb
@@ -5,7 +5,7 @@
   <div class="carousel-inner shadow">
     <% images.each_with_index do |image, idx| %>
       <div class="<%= 'active' if idx.zero? %> carousel-item" data-slide-number="<%= idx %>">
-        <%= image_tag image.url, class: 'd-block w-100', alt: "Image #{idx + 1} of #{images.size}" %>
+        <%= image_tag image.full_url, class: 'd-block w-100', alt: "Image #{idx + 1} of #{images.size}" %>
       </div>
     <% end %>
 
@@ -27,7 +27,7 @@
                     id: "carousel-selector-#{idx}",
                     class: idx.zero? ? 'selected' : '',
                     data: { 'slide-to': idx, target: '#homeImagesCarousel' } do %>
-          <%= image_tag image.url, class: 'img-fluid', style: 'max-height: 100px;', alt: "Image #{idx + 1} of #{images.size}" %>
+          <%= image_tag image.thumb_url, class: 'img-fluid', style: 'max-height: 100px;', alt: "Image #{idx + 1} of #{images.size}" %>
         <% end %>
       </li>
     <% end %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -5,7 +5,7 @@
 <% if @homes.each do |home| %>
   <div class="media">
     <%= link_to hunt_home_path(@hunt, home), class: 'align-self-center' do %>
-      <%= image_tag home.default_image, height: 100, class: 'mr-3', alt: home.address_street %>
+      <%= image_tag home.default_thumb, height: 100, class: 'mr-3', alt: home.address_street %>
     <% end %>
     <div class="media-body">
       <h5 class="mt-0">

--- a/db/migrate/20200906233256_rename_image_url_to_external_url.rb
+++ b/db/migrate/20200906233256_rename_image_url_to_external_url.rb
@@ -1,0 +1,5 @@
+class RenameImageUrlToExternalUrl < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :images, :url, :external_url
+  end
+end

--- a/db/migrate/20200906234859_add_persisted_urls_to_image.rb
+++ b/db/migrate/20200906234859_add_persisted_urls_to_image.rb
@@ -1,0 +1,6 @@
+class AddPersistedUrlsToImage < ActiveRecord::Migration[6.0]
+  def change
+    add_column :images, :full_url, :string
+    add_column :images, :thumb_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_06_233256) do
+ActiveRecord::Schema.define(version: 2020_09_06_234859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,8 @@ ActiveRecord::Schema.define(version: 2020_09_06_233256) do
     t.integer "home_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "full_url"
+    t.string "thumb_url"
     t.index ["home_id"], name: "index_images_on_home_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_27_222828) do
+ActiveRecord::Schema.define(version: 2020_09_06_233256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 2020_07_27_222828) do
   end
 
   create_table "images", id: :serial, force: :cascade do |t|
-    t.string "url", null: false
+    t.string "external_url", null: false
     t.integer "home_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Background job to (when manually triggered, for now) backup an image's "external" (i.e. Zoopla/Rightmove) URL by triggering Transloadit to generate a thumbnail and store both the original and thumbnail on S3.